### PR TITLE
Added an additional condition to check if xml.attributes is null, ins…

### DIFF
--- a/src/xml2json.js
+++ b/src/xml2json.js
@@ -104,8 +104,8 @@
 			xml = parseXML(xml).documentElement;
 		}
 
-		var root = {};
-		if (typeof xml.attributes === 'undefined') {
+		var root = {};		
+		if ( (typeof xml.attributes === 'undefined') || (xml.attributes === null) ) {
 			root[xml.nodeName] = xml2jsonImpl(xml, options);
 		} else if (xml.attributes.length === 0 && xml.childElementCount === 0){
 			root[xml.nodeName] = normalize(xml.textContent, options);


### PR DESCRIPTION
…ide the xml2json function.

In Internet Explorer 11, I was experiencing an issue where xml.attributes was null, and this would result in the subsequent "} else if (xml.attributes.length ...) {" being evaluated and throwing an exception.